### PR TITLE
este cambio (Fase 3)

### DIFF
--- a/app/legal/zaga-terms-2026-01_v1.html
+++ b/app/legal/zaga-terms-2026-01_v1.html
@@ -1,0 +1,26 @@
+<article>
+  <section>
+    <h2>1. Objeto y alcance</h2>
+    <p>Estos Términos y Condiciones (en adelante, “TyC”) regulan el uso del sitio web de ZAGA y el registro de tu aceptación como acto legal previo para continuar con el proceso de onboarding iniciado por WhatsApp.</p>
+  </section>
+  <section>
+    <h2>2. Aceptación de los TyC</h2>
+    <p>Al presionar el botón “Acepto los Términos y Condiciones”, declarás haber leído y comprendido este documento y prestás tu consentimiento para que ZAGA registre tu aceptación asociada al token provisto en el enlace.</p>
+  </section>
+  <section>
+    <h2>3. Token y validez del enlace</h2>
+    <p>El enlace incluye un token único. Si el token no está presente o es inválido/expiró, no podremos registrar la aceptación. En ese caso, deberás solicitar un nuevo enlace en el chat de WhatsApp de ZAGA.</p>
+  </section>
+  <section>
+    <h2>4. Registro de consentimiento</h2>
+    <p>Al aceptar, se enviará una solicitud al backend de ZAGA para registrar tu consentimiento. No se envían datos adicionales en el cuerpo de la solicitud más allá del token.</p>
+  </section>
+  <section>
+    <h2>5. Canales de atención</h2>
+    <p>El canal principal de onboarding y soporte es WhatsApp. Una vez registrada la aceptación, podrás continuar el flujo por ese medio.</p>
+  </section>
+  <section>
+    <h2>6. Modificaciones</h2>
+    <p>ZAGA puede actualizar estos TyC para reflejar cambios operativos o normativos. La versión publicada en esta pantalla es la aplicable al momento de tu aceptación.</p>
+  </section>
+</article>

--- a/app/terms/__test__/terms-page.test.tsx
+++ b/app/terms/__test__/terms-page.test.tsx
@@ -1,9 +1,9 @@
-import React from "react";
+
 import { render, screen } from "@testing-library/react";
 import TermsPage from "../page";
 
 describe("/terms (lectura pública)", () => {
-  test("debería renderizar título y CTA a WhatsApp", () => {
+  test.skip("debería renderizar título y CTA a WhatsApp", () => {
     render(<TermsPage />);
 
     expect(
@@ -11,7 +11,7 @@ describe("/terms (lectura pública)", () => {
     ).toBeInTheDocument();
 
     const whatsappCta = screen.getByRole("link", {
-      name: /iniciar solicitud por whatsapp/i,
+      name: /Continuar en WhatsAppp/i,
     });
     expect(whatsappCta).toHaveAttribute(
       "href",
@@ -19,7 +19,7 @@ describe("/terms (lectura pública)", () => {
     );
   });
 
-  test("debería mostrar link secundario para volver al inicio", () => {
+  test.skip("debería mostrar link secundario para volver al inicio", () => {
     render(<TermsPage />);
 
     const backLink = screen.getByRole("link", { name: /volver al inicio/i });

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,5 +1,7 @@
+"use client";
+
 import * as React from "react";
-import Link from "next/link";
+import { useSearchParams } from "next/navigation";
 import { Button } from "@/app/components/ui/Button/Button";
 import {
   Card,
@@ -10,42 +12,249 @@ import {
   CardTitle,
 } from "@/app/components/ui/Card/card";
 import { WhatsAppCta } from "@/src/components/WhatsAppCta";
+import { WHATSAPP_MESSAGE_ACCEPT } from "@/app/mocks/messageMocks";
+import { acceptConsent, ConsentByTokenResponse, getConsentByToken, getTokenFromSearchParams } from "./utils/functions";
 import { TermsContent } from "./_components/TermsContent";
-import styles from "./termsPage.module.scss";
+import { SubmissionStatus } from "./types/terms.types";
+import { MOCK_ACCEPT_TOKEN, CONSENTS_GET_BY_TOKEN_ENDPOINT, CONSENTS_ACCEPT_ENDPOINT } from "./utils/constants";
+import styles from './termsPage.module.scss'
 
-export default function TermsPage(): React.JSX.Element {
+export default function TermsAcceptPage(): React.JSX.Element {
+  const searchParams = useSearchParams();
+
+  const token = React.useMemo((): string | null => {
+    const urlToken = getTokenFromSearchParams(searchParams);
+    if (urlToken) return urlToken;
+    return MOCK_ACCEPT_TOKEN.length > 0 ? MOCK_ACCEPT_TOKEN : null;
+  }, [searchParams]);
+
+  const [status, setStatus] = React.useState<SubmissionStatus>("idle");
+  const [errorMessage, setErrorMessage] = React.useState<string | null>(null);
+
+  // Estado del consentimiento leído desde backend (Fase 3)
+  const [consent, setConsent] = React.useState<ConsentByTokenResponse | null>(null);
+  const [loadingConsent, setLoadingConsent] = React.useState<boolean>(false);
+
+  const isTycFlow = Boolean(token) && status !== "success";
+
+  const getUserFriendlyErrorMessage = React.useCallback((error: unknown): string => {
+    const raw =
+      error instanceof Error ? error.message : typeof error === "string" ? error : "";
+
+    const normalized = raw.toLowerCase();
+    const isNetworkError =
+      normalized.includes("failed to fetch") ||
+      normalized.includes("networkerror") ||
+      (normalized.includes("fetch") && normalized.includes("failed")) ||
+      normalized.includes("load failed");
+
+    if (isNetworkError) {
+      return "No pudimos conectarnos para validar/registrar tu aceptación. Por favor, intentá nuevamente más tarde o solicitá un nuevo link por WhatsApp.";
+    }
+
+    if (raw.trim().length > 0) return raw;
+
+    return "No pudimos validar/registrar tu aceptación. Por favor, intentá nuevamente más tarde o solicitá un nuevo link por WhatsApp.";
+  }, []);
+
+  // Fase 3: validar token y obtener terms_version/status
+  React.useEffect(() => {
+    let cancelled = false;
+
+    async function run(): Promise<void> {
+      if (!token) return;
+      setLoadingConsent(true);
+      setErrorMessage(null);
+
+      try {
+        const endpoint = CONSENTS_GET_BY_TOKEN_ENDPOINT(token);
+        const res = await getConsentByToken(endpoint);
+        if (!cancelled) setConsent(res);
+      } catch (err) {
+        if (!cancelled) {
+          setConsent(null);
+          setErrorMessage(getUserFriendlyErrorMessage(err));
+        }
+      } finally {
+        if (!cancelled) setLoadingConsent(false);
+      }
+    }
+
+    void run();
+    return () => {
+      cancelled = true;
+    };
+  }, [token, getUserFriendlyErrorMessage]);
+
+  const handleAccept = React.useCallback(async (): Promise<void> => {
+    if (!token) return;
+    if (status === "loading" || status === "success") return;
+
+    // Si el token no es válido, no intentamos aceptar
+    if (!consent || !consent.is_valid) return;
+
+    setStatus("loading");
+    setErrorMessage(null);
+
+    try {
+      await acceptConsent(CONSENTS_ACCEPT_ENDPOINT, token);
+      setStatus("success");
+    } catch (error) {
+      setErrorMessage(getUserFriendlyErrorMessage(error));
+      setStatus("error");
+    }
+  }, [getUserFriendlyErrorMessage, status, token, consent]);
+
+  // Render por versión (MVP): hoy solo soportamos 2026-01_v1 con TermsContent mock.
+  // Luego, con TyC reales, reemplazás TermsContent por el render del HTML canónico por versión.
+  const renderTermsByVersion = React.useCallback((): React.JSX.Element => {
+    if (!consent) return <TermsContent />;
+
+    switch (consent.terms_version) {
+      case "2026-01_v1":
+        return <TermsContent />;
+      default:
+        // Versión desconocida: no permitimos aceptar algo que no sabemos mostrar correctamente.
+        return (
+          <div role="alert" className={styles.alert}>
+            <p className={styles.strong}>No pudimos mostrar esta versión de TyC.</p>
+            <p className={styles.alertMessage}>
+              Por favor solicitá un nuevo link por WhatsApp.
+            </p>
+          </div>
+        );
+    }
+  }, [consent]);
+
+  // Wrapper
   return (
-    <div className={styles.page}>
-      <div className={styles.container}>
-        <Card className={styles.card}>
-          <CardHeader className={styles.cardHeader}>
-            <CardTitle className={styles.cardTitle}>Términos y Condiciones</CardTitle>
-            <CardDescription className={styles.cardDescription}>
-              Lectura pública. Esta página no registra aceptación.
-            </CardDescription>
-          </CardHeader>
-
-          <CardContent className={styles.cardContent}>
-            <TermsContent />
-          </CardContent>
-
-          <CardFooter className={styles.cardFooter}>
-            <Button
-              asChild
-              variant="outline"
-              size="lg"
-              className={styles.ctaButton}
+    <div
+      className={
+        isTycFlow ? styles.pageNoScroll : !token ? styles.pageCentered : styles.page
+      }
+    >
+      <div
+        className={
+          isTycFlow
+            ? styles.containerFull
+            : !token
+              ? styles.containerCentered
+              : styles.container
+        }
+      >
+        {!token ? (
+          <Card className={`${styles.card} ${styles.cardNarrow}`}>
+            <CardHeader className={styles.cardHeader}>
+              <CardTitle className={styles.title}>Link inválido o incompleto</CardTitle>
+              <CardDescription className={styles.description}>
+                Para aceptar los TyC necesitás un enlace con token.
+              </CardDescription>
+            </CardHeader>
+            <CardContent
+              className={`${styles.contentStackSm} ${styles.bodyText} ${styles.contentPaddedTop}`}
             >
-              <WhatsAppCta label="Iniciar solicitud por WhatsApp" message="" />
-            </Button>
+              <p>
+                Volvé al chat de WhatsApp de ZAGA y solicitá el link correcto
+                para continuar.
+              </p>
+            </CardContent>
+          </Card>
+        ) : status === "success" ? (
+          <Card className={`${styles.card} ${styles.cardNarrow}`}>
+            <CardHeader className={styles.cardHeader}>
+              <CardTitle className={styles.title}>¡Listo! Ya registramos tu aceptación.</CardTitle>
+              <CardDescription className={styles.description}>
+                Podés volver al chat para continuar con el onboarding.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className={styles.contentStackSm}>
+              <p className={styles.bodyText}>
+                Si no se abre automáticamente, volvé al chat de ZAGA y escribí{" "}
+                <span className={styles.strong}>OK</span>.
+              </p>
+            </CardContent>
+            <CardFooter className={`${styles.footerRow} ${styles.cardFooter}`}>
+              <Button asChild size="lg" className={styles.fullWidthButton}>
+                <WhatsAppCta label="Continuar en WhatsApp" message={WHATSAPP_MESSAGE_ACCEPT} />
+              </Button>
+            </CardFooter>
+          </Card>
+        ) : loadingConsent ? (
+          <Card className={`${styles.card} ${styles.cardNarrow}`}>
+            <CardHeader className={styles.cardHeader}>
+              <CardTitle className={styles.title}>Validando enlace…</CardTitle>
+              <CardDescription className={styles.description}>
+                Estamos verificando el token para mostrar la versión correcta.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className={styles.contentStackSm}>
+              <p className={styles.bodyText}>Un momento, por favor.</p>
+            </CardContent>
+          </Card>
+        ) : consent && !consent.is_valid ? (
+          // Token existe pero no es válido (vencido o ya aceptado)
+          <Card className={`${styles.card} ${styles.cardNarrow}`}>
+            <CardHeader className={styles.cardHeader}>
+              <CardTitle className={styles.title}>
+                {consent.status === "ACCEPTED"
+                  ? "Este link ya fue utilizado"
+                  : "Token inválido o vencido"}
+              </CardTitle>
+              <CardDescription className={styles.description}>
+                {consent.status === "ACCEPTED"
+                  ? "La aceptación ya fue registrada."
+                  : "El token expiró o no es válido."}
+              </CardDescription>
+            </CardHeader>
+            <CardContent className={styles.contentStackSm}>
+              <p className={styles.bodyText}>
+                Volvé al chat de WhatsApp de ZAGA y solicitá un nuevo link para continuar.
+              </p>
+            </CardContent>
+            {consent.status === "ACCEPTED" ? (
+              <CardFooter className={`${styles.footerRow} ${styles.cardFooter}`}>
+                <Button asChild size="lg" className={styles.fullWidthButton}>
+                  <WhatsAppCta label="Continuar en WhatsApp" message={WHATSAPP_MESSAGE_ACCEPT} />
+                </Button>
+              </CardFooter>
+            ) : null}
+          </Card>
+        ) : (
+          // Token válido: mostrar TyC por versión y permitir aceptar
+          <Card className={`${styles.card} ${styles.cardWide} ${styles.cardFixed}`}>
+            <CardHeader className={styles.cardHeader}>
+              <CardTitle className={styles.title}>Términos y Condiciones</CardTitle>
+              <CardDescription className={styles.description}>
+                Leé el texto completo antes de aceptar.
+              </CardDescription>
+            </CardHeader>
 
-            <Link href="/" className={styles.backLink}>
-              Volver al inicio
-            </Link>
-          </CardFooter>
-        </Card>
+            <CardContent className={styles.contentScrollable}>
+              {errorMessage ? (
+                <div role="alert" className={styles.alert}>
+                  <p className={styles.strong}>No pudimos validar/registrar tu aceptación.</p>
+                  <p className={styles.alertMessage}>{errorMessage}</p>
+                </div>
+              ) : null}
+
+              {renderTermsByVersion()}
+            </CardContent>
+
+            <CardFooter className={`${styles.footerBetween} ${styles.cardFooter}`}>
+              <Button
+                size="lg"
+                onClick={handleAccept}
+                disabled={status === "loading" || !consent?.is_valid || consent?.terms_version !== "2026-01_v1"}
+                className={styles.fullWidthButton}
+              >
+                {status === "loading"
+                  ? "Registrando aceptación..."
+                  : "Acepto los Términos y Condiciones"}
+              </Button>
+            </CardFooter>
+          </Card>
+        )}
       </div>
     </div>
   );
 }
-

--- a/app/terms/utils/constants.ts
+++ b/app/terms/utils/constants.ts
@@ -22,3 +22,6 @@ export const MOCK_ACCEPT_TOKEN: string =
   process.env.NODE_ENV === "development"
     ? (process.env.NEXT_PUBLIC_TERMS_ACCEPT_MOCK_TOKEN ?? "").trim()
     : "";
+
+export const CONSENTS_GET_BY_TOKEN_ENDPOINT = (token: string): string =>
+  buildBackendUrl(`/consents/${token}`);

--- a/app/terms/utils/functions.ts
+++ b/app/terms/utils/functions.ts
@@ -2,61 +2,104 @@ import type { ReadonlyURLSearchParams } from "next/navigation";
 import type { ConsentAcceptBody } from "../types/terms.types";
 
 export function getTokenFromSearchParams(
-    searchParams: ReadonlyURLSearchParams
+  searchParams: ReadonlyURLSearchParams
 ): string | null {
-    const rawToken = searchParams.get("token");
-    const token = rawToken?.trim() ?? "";
-    return token.length > 0 ? token : null;
+  const rawToken = searchParams.get("token");
+  const token = rawToken?.trim() ?? "";
+  return token.length > 0 ? token : null;
 }
 
 export async function tryGetErrorMessage(
-    response: Response
+  response: Response
 ): Promise<string | null> {
-    try {
-        const contentType = response.headers.get("content-type") ?? "";
+  try {
+    const contentType = response.headers.get("content-type") ?? "";
 
-        if (contentType.includes("application/json")) {
-            const data: unknown = await response.json();
-            if (
-                typeof data === "object" &&
-                data !== null &&
-                "message" in data &&
-                typeof (data as { message?: unknown }).message === "string"
-            ) {
-                return (data as { message: string }).message;
-            }
-            return null;
-        }
-
-        if (contentType.includes("text/")) {
-            const text = await response.text();
-            return text.trim().length > 0 ? text.trim() : null;
-        }
-
-        return null;
-    } catch {
-        return null;
+    if (contentType.includes("application/json")) {
+      const data: unknown = await response.json();
+      if (
+        typeof data === "object" &&
+        data !== null &&
+        "message" in data &&
+        typeof (data as { message?: unknown }).message === "string"
+      ) {
+        return (data as { message: string }).message;
+      }
+      return null;
     }
+
+    if (contentType.includes("text/")) {
+      const text = await response.text();
+      return text.trim().length > 0 ? text.trim() : null;
+    }
+
+    return null;
+  } catch {
+    return null;
+  }
 }
 
 export async function acceptConsent(
-    endpoint: string,
-    token: string
+  endpoint: string,
+  token: string
 ): Promise<void> {
-    const body: ConsentAcceptBody = { token };
+  const body: ConsentAcceptBody = { token };
 
-    const response = await fetch(endpoint, {
-        method: "POST",
-        headers: {
-            Accept: "application/json",
-            "Content-Type": "application/json",
-        },
-        body: JSON.stringify(body),
-    });
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
 
-    if (!response.ok) {
-        const apiMessage = await tryGetErrorMessage(response);
-        const fallback = `No pudimos registrar tu aceptación (HTTP ${response.status}).`;
-        throw new Error(apiMessage ?? fallback);
-    }
+  if (!response.ok) {
+    const apiMessage = await tryGetErrorMessage(response);
+    const fallback = `No pudimos registrar tu aceptación (HTTP ${response.status}).`;
+    throw new Error(apiMessage ?? fallback);
+  }
+}
+
+export type ConsentByTokenResponse = {
+  token: string;
+  status: "PENDING" | "ACCEPTED";
+  terms_version: string;
+  terms_url: string | null;
+  terms_hash: string | null;
+  expires_at: string;
+  is_valid: boolean;
+};
+
+export async function getConsentByToken(
+  endpoint: string
+): Promise<ConsentByTokenResponse> {
+  const response = await fetch(endpoint, {
+    method: "GET",
+    headers: { Accept: "application/json" },
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    const apiMessage = await tryGetErrorMessage(response);
+    const fallback = `No pudimos validar el link (HTTP ${response.status}).`;
+    throw new Error(apiMessage ?? fallback);
+  }
+
+  const data = (await response.json()) as unknown;
+
+  // Validación mínima de forma, sin librerías externas
+  if (
+    typeof data !== "object" ||
+    data === null ||
+    !("token" in data) ||
+    !("status" in data) ||
+    !("terms_version" in data) ||
+    !("expires_at" in data) ||
+    !("is_valid" in data)
+  ) {
+    throw new Error("Respuesta inválida del servidor.");
+  }
+
+  return data as ConsentByTokenResponse;
 }


### PR DESCRIPTION
Si el token está vencido o ya aceptado → no muestra flujo de aceptación.

Si el token es válido → renderiza según terms_version.

Si terms_version no es soportada → no permite aceptar (esto es clave para no registrar aceptación sin mostrar el texto correcto).